### PR TITLE
Access png/jpg image generation functionality from dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Contributed initial build of R package.
+* Added access to cytoscape.js PNG and JPG image generation API through `generateImage` and
+  `imageData` properties.
+* Added ability to download image files generated with `generateImage` client-side without sending 
+  data to the server.
 
 ### Changed
 * `utils.Tree`: v0.1.1 broke compatibility with Python 2. Therefore, modified code to be compatible

--- a/src/lib/components/Cytoscape.react.js
+++ b/src/lib/components/Cytoscape.react.js
@@ -281,7 +281,7 @@ class Cytoscape extends Component {
     }
     
     handleImageGeneration(imageType, options) {
-        var {imageOptions, downloadImage, sendCallbackData, fileName} = options
+        var {imageOptions, downloadImage, storeImage, fileName} = options
         var desiredOutput = imageOptions.output
         imageOptions.output = 'blob'
         
@@ -299,27 +299,28 @@ class Cytoscape extends Component {
             }
             
             /*
-             * Thank you to koldev https://jsfiddle.net/koldev/cW7W5/
+             * Download blob as file
+             * Thank you, koldev https://jsfiddle.net/koldev/cW7W5/
              */
-            var a = document.createElement("a");
-            a.style = "display: none";
-            document.body.appendChild(a);
+            var downloadLink = document.createElement("a")
+            downloadLink.style = "display: none"
+            document.body.appendChild(downloadLink)
             
-            var url = window.URL.createObjectURL(output);
-            a.href = url;
-            a.download = fileName + '.' + imageType;
-            a.click();
-            window.URL.revokeObjectURL(url);
+            const url = window.URL.createObjectURL(output)
+            downloadLink.href = url
+            downloadLink.download = fileName + '.' + imageType
+            downloadLink.click()
+            window.URL.revokeObjectURL(url)
             
-            document.body.removeChild(a)
+            document.body.removeChild(downloadLink)
         }
         
-        if (output && sendCallbackData) {
+        if (output && storeImage) {
             if (!desiredOutput) {
                 desiredOutput = 'base64uri'
             }
             
-            if (!(['base64', 'base64uri'].includes(desiredOutput))) {
+            if (!(desiredOutput === 'base64uri' || desiredOutput === 'base64')) {
                 return
             }
             
@@ -327,11 +328,11 @@ class Cytoscape extends Component {
              * Convert blob to base64uri or base64 string
              * Thank you, base64guru https://base64.guru/developers/javascript/examples/encode-blob
              */
-            var reader = new FileReader();
+            var reader = new FileReader()
             reader.onload = () => {
                 var callbackData = reader.result
                 if (desiredOutput === 'base64') {
-                    callbackData = callbackData.replace(/^data:.+;base64,/, '');
+                    callbackData = callbackData.replace(/^data:.+;base64,/, '')
                 }
                 this.props.setProps({'imageData': callbackData})
             }
@@ -363,7 +364,7 @@ class Cytoscape extends Component {
             autoungrabify,
             autolock,
             autounselectify,
-            // PNG handling
+            // Image handling
             generateImage
         } = this.props;
         
@@ -375,8 +376,8 @@ class Cytoscape extends Component {
                 this.handleImageGeneration(
                     generateImage.type,
                     {'imageOptions': generateImage.options,
-                     'downloadImage': (generateImage.download === true),
-                     'sendCallbackData': !(generateImage.callback === false),
+                     'downloadImage': (generateImage.download === true),    // Default is false
+                     'storeImage': !(generateImage.store === false),        // Default is true
                      'fileName': generateImage.filename}
                 )
             }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: 
https://github.com/plotly/dash-cytoscape/blob/master/CONTRIBUTING.md
-->


## About
<!--
What is your PR about? It could be that:
- This is a new component
- I am adding a feature to an existing component, or improving an existing feature
- I am closing an issue
--> 
This PR provides access to the existing Cytoscape.js image generation APIs, `cy.png()` and `cy.jpg()`, via Dash callbacks. It allows the current view of a Cytoscape graph to be saved as an image, stored as a base64 string or data URL, and/or downloaded as a file.

## Description of changes 
<!--
What does this implement/fix? Explain your changes.
-->
This PR adds `generateImage` and `imageData` properties to `dash-cytoscape`.

To initiate image generation, `generateImage` is set using a Dash callback. It requires a dictionary with the following structure:
- `type` (string, required): File type to ouput of 'png', 'jpg', or 'jpeg' (alias of 'jpg')
- `options` (dictionary, optional): Dictionary of options to `cy.png()` or `cy.jpg()` for image generation. See http://js.cytoscape.org/#core/export for details. For `'output'`, only 'base64' and 'base64uri' are supported. Default: `{'output': 'base64uri'}`.
- `action` (string, optional): Default: `'store'`. Must be one of the following:
    - `'store'`: Stores the image data in `imageData` and invokes server-side Dash callbacks.
    - `'download'`: Downloads the image as a file with all data handling done client-side. No `imageData` callbacks are fired.
    - `'both'`: Stores image data and downloads image as file.
- `filename` (string, optional): Name for the file to be downloaded. Default: 'cyto'.

If `action` is `'store'` or `'both'`, the image data (as data URL or base64 string, depending on specification in `options`) is stored in `imageData`, invoking a Dash callback that can be handled on the server. However, because these images can be large (megabytes), it may be prudent to download them as files instead of sending them to the server. Specifying `action` as `'download'` or `'both'` will initiate a download of the image file.

## Pre-Merge checklist
- [x] The project was correctly built with `npm run build:all`.
- [x] If there was any conflict, it was solved correctly
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed. **(Master fails the `test.test_interactive` test)**
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash Cytoscape core contributor.


## Reference Issues
<!--
Example: Closes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests

If you are adding a new feature, consider discussing it by opening up an issue.
Otherwise, delete the following line:
-->

No current issues related to this PR.


## Other comments
**Please note that I am an entirely novice React/JavaScript user.** This is my first attempt at this kind of project, so constructive feedback is welcome!

I did not write any specific tests for this addition, nor am I sure how to test with the selenium framework. I did test manually using an example Dash app placed in the repo root directory:

```
import dash
import dash_core_components as dcc
import dash_html_components as html
from dash.exceptions import PreventUpdate
from dash.dependencies import Input, Output
import dash_cytoscape as cyto

app = dash.Dash(__name__)
server = app.server
app.scripts.config.serve_locally = True
app.title = "test-dc"
route = dcc.Location(id='url', refresh=False)

elements = [
    {
            'data': {'id': 'one', 'label': 'Node 1'},
            'position': {'x': 50, 'y': 50}
    },
    {
            'data': {'id': 'two', 'label': 'Node 2'},
            'position': {'x': 200, 'y': 200}
    },
    {
            'data': {
                'source': 'one',
                'target': 'two',
                'label': 'Edge from Node1 to Node2'
    }}
]

app.layout = html.Div(
    children=[route,
              html.H1('My app'),
              html.Button('Get Image', id='button'),
              # Specifying generateImage here should do nothing
              cyto.Cytoscape(id='cy', elements=elements, generateImage={'type': 'png'}),
              dcc.Textarea('image-text', value='Image data here')
              ]
)

@app.callback(Output('cy', 'generateImage'),
              [Input('button', 'n_clicks')])
def get_image(n_clicks):
    if (n_clicks is None):
        raise PreventUpdate
    # Set options here
    return {'type': 'png',
    }


@app.callback(Output('image-text', 'value'),
              [Input('cy', 'imageData')])
def put_image_string(data):
    return data

if __name__ == '__main__':
    app.run_server(debug=False)
```